### PR TITLE
feat: Mejora contador de filtros y añade resaltado visual

### DIFF
--- a/assets/css/buscar-pubmed.css
+++ b/assets/css/buscar-pubmed.css
@@ -863,3 +863,24 @@ body {
 .chatgpt-button:hover i {
   color: #a78bfa; /* Un tono un poco más claro al pasar el ratón */
 }
+
+.filter-count.highlighted {
+  background-color: rgba(
+    174,
+    23,
+    23,
+    0.1
+  ); /* Fondo semitransparente blanco o gris claro */
+  color: var(--accent-color, #ffd700); /* Texto en color acento (amarillo) */
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: bold;
+  margin-left: 5px;
+  transition: background-color 0.3s ease, color 0.3s ease, text-shadow 0.3s ease; /* Añadida transición para sombra */
+  border: 1px solid rgba(255, 255, 255, 0.2); /* Borde sutil opcional */
+
+  /* --- NUEVAS LÍNEAS PARA DESTACAR MÁS EL NÚMERO --- */
+  font-size: 1.3em; /* Hacemos el número un 5% más grande que el texto normal */
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5); /* Sombra oscura sutil (ajusta opacidad 0.5 si es mucho/poco) */
+  /* --- FIN NUEVAS LÍNEAS --- */
+}

--- a/buscar-pubmed.html
+++ b/buscar-pubmed.html
@@ -1223,15 +1223,17 @@ filtros estructurados para profesionales sanitarios
               }
             });
 
+            updateFilterCounterDisplay(); // Actualizar el contador de filtros
+            mostrarQueryFinal();
+
+            // Llamar al trigger externo si existe nuevo cambio estaba antes de updateFilterCounterDisplay
+
             // ---> ¡AÑADIR ESTA LÍNEA! <---
             // Disparar la actualización de los contadores con el estado recuperado
             if (typeof window.triggerPubMedCounterUpdate === "function") {
               window.triggerPubMedCounterUpdate();
             }
             // ---> FIN DE LÍNEA A AÑADIR <---
-
-            filterCount.textContent = activeFilters.size;
-            mostrarQueryFinal();
             mostrarToast(`Búsqueda "${nombre}" recuperada correctamente.`);
             cerrarModal("modalRecuperarFondo");
           });
@@ -1676,6 +1678,30 @@ filtros estructurados para profesionales sanitarios
             });
           });
         });
+
+        // ---> NUEVA FUNCIÓN CENTRALIZADA PARA ACTUALIZAR EL CONTADOR <---
+        function updateFilterCounterDisplay() {
+          const buttonFilterCount = activeFilters.size; // Número de filtros de botón activos
+          const isDateFilterActive = dateRange.value !== ""; // ¿Hay un filtro de fecha seleccionado? (' !== "" ' significa que cualquier opción excepto "Sin Filtro" está seleccionada)
+
+          // Calcula el total de filtros activos (botones + fecha)
+          const totalActiveFilters =
+            buttonFilterCount + (isDateFilterActive ? 1 : 0);
+
+          // Actualiza el texto del contador
+          filterCount.textContent = totalActiveFilters;
+
+          // Resalta el contador si hay 1 o más filtros activos
+          if (totalActiveFilters > 0) {
+            filterCount.classList.add("highlighted");
+          } else {
+            filterCount.classList.remove("highlighted");
+          }
+        }
+        // ---> FIN NUEVA FUNCIÓN <---
+
+        // 5. Event Listeners básicos (MODIFICADOS)
+        // ... resto del script ...
         // 5. Event Listeners básicos (REEMPLAZO CONSERVADOR)
 
         // Listener para searchTerm (Input) - Solo para mostrar query.
@@ -1685,12 +1711,12 @@ filtros estructurados para profesionales sanitarios
           searchTerm.addEventListener("input", mostrarQueryFinal);
         }
 
-        // Listener para dateRange (Change) - Muestra query Y actualiza contadores
+        // Listener para dateRange (Change) - Muestra query Y actualiza contador VISUAL
         if (dateRange) {
-          // Añadir comprobación
           dateRange.addEventListener("change", function () {
             mostrarQueryFinal();
-            // Disparar actualización de contadores
+            updateFilterCounterDisplay(); // <-- USA LA NUEVA FUNCIÓN para actualizar número y resaltado
+            // Llama a la función global del script de contadores externo si existe
             if (typeof window.triggerPubMedCounterUpdate === "function") {
               window.triggerPubMedCounterUpdate();
             }
@@ -1716,7 +1742,7 @@ filtros estructurados para profesionales sanitarios
                 } else {
                   activeFilters.delete(filterType);
                 }
-                filterCount.textContent = activeFilters.size;
+                updateFilterCounterDisplay(); // <-- USA LA NUEVA FUNCIÓN para actualizar número y resaltado
                 mostrarQueryFinal();
                 // ---> ¡AÑADIR ESTA LÍNEA! <---
                 if (typeof window.triggerPubMedCounterUpdate === "function") {
@@ -1749,7 +1775,7 @@ filtros estructurados para profesionales sanitarios
               } else {
                 activeFilters.delete(filterType);
               }
-              filterCount.textContent = activeFilters.size;
+              updateFilterCounterDisplay(); // <-- USA LA NUEVA FUNCIÓN para actualizar número y resaltado
               mostrarQueryFinal();
               // ---> ¡AÑADIR ESTA LÍNEA! <---
               if (typeof window.triggerPubMedCounterUpdate === "function") {
@@ -1768,7 +1794,7 @@ filtros estructurados para profesionales sanitarios
                 var newType = baseId + "_" + radio.value;
                 activeFilters.delete(oldType);
                 activeFilters.add(newType);
-                filterCount.textContent = activeFilters.size;
+                updateFilterCounterDisplay(); // <-- USA LA NUEVA FUNCIÓN para actualizar número y resaltado
                 mostrarQueryFinal();
               });
             });
@@ -1863,7 +1889,6 @@ filtros estructurados para profesionales sanitarios
         // 11. Event listener para reset
         resetButton.addEventListener("click", function () {
           activeFilters.clear();
-          filterCount.textContent = 0;
           searchTerm.value = "";
           dateRange.value = "";
           sortMode.value = "date";
@@ -1886,6 +1911,8 @@ filtros estructurados para profesionales sanitarios
             });
 
           finalQueryBox.textContent = "";
+          updateFilterCounterDisplay();
+
           mostrarQueryFinal();
           // ---> AÑADIR ESTA LÍNEA (Opcional) <---
           if (typeof window.triggerPubMedCounterUpdate === "function") {
@@ -2251,6 +2278,10 @@ filtros estructurados para profesionales sanitarios
         if (startTutorialBtn) {
           startTutorialBtn.addEventListener("click", iniciarTutorial);
         }
+        // Llamada inicial para establecer el estado correcto del contador al cargar la página
+        updateFilterCounterDisplay();
+        // Llamada inicial para mostrar la query (por si hubiera valores prellenados o restaurados)
+        mostrarQueryFinal(); // (Esta llamada probablemente ya estaba o es buena idea tenerla)
       });
       // Activar/desactivar botones según contenido
       document


### PR DESCRIPTION
**Resumen**

Este Pull Request mejora la funcionalidad y la interfaz del contador de filtros activos en el buscador avanzado de PubMed. Aborda varios puntos:

1.  **Inclusión del Filtro de Fecha:** El contador ahora refleja correctamente la selección de un rango de fechas como un filtro activo.
2.  **Resaltado Visual:** Se ha añadido un estilo CSS (`.filter-count.highlighted`) y la lógica JavaScript necesaria para resaltar visualmente el contador cuando hay 1 o más filtros activos (incluyendo el de fecha). Esto mejora la visibilidad del estado de los filtros.
3.  **Estilo de Resaltado Mejorado:** Se ha ajustado el estilo del contador resaltado (aumento ligero de tamaño, sombra de texto) para mejorar su prominencia visual sobre el fondo, basado en feedback de diseño.
4.  **Corrección Botón Limpiar:** Se ha solucionado un bug por el que era necesario pulsar dos veces el botón "Limpiar" para que el contador dejara de estar resaltado. Esto se debió a un orden incorrecto en la ejecución de la limpieza del estado y la actualización del contador en el listener del botón.

**Cambios Técnicos Principales**

* Se creó la función `updateFilterCounterDisplay` para centralizar la lógica de actualización del texto y la clase CSS del contador.
* Se modificaron los listeners de eventos para `dateRange`, botones de filtro (`.filter-button`), `resetButton` y `recuperarBusquedaConfirm` para utilizar `updateFilterCounterDisplay`.
* Se corrigió el orden de las operaciones dentro del listener de `resetButton`.
* Se añadieron/modificaron las reglas CSS para `.filter-count.highlighted`.

**Cómo Probar**

1.  Activa/desactiva filtros de botón y observa que el contador se actualiza y se resalta/desresalta.
2.  Selecciona/deselecciona un rango de fechas y verifica que el contador se incrementa/decrementa y se resalta/desresalta correctamente.
3.  Activa varios filtros (botones y fecha). Pulsa "Limpiar" una sola vez y confirma que todos los filtros se desactivan, el contador muestra 0 y el resaltado desaparece.
4.  Guarda y recupera una búsqueda con filtros activos (incluyendo fecha) y verifica que el contador se restaura correctamente.